### PR TITLE
Feat/tag-based-test-filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ To execute Unit tests run: `mvn test`
 Create the package: `mvn package`
 
 To execute Integration tests:
-- Stack Docker daemon or Docker Desktop
-- Run `mvn integration-test`
+- Start Docker daemon or Docker Desktop
+- Run `mvn test -Pintegration-test`
 
 ## Run the application
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,9 +57,9 @@
       <version>${spark.version}</version>
     </dependency>
     <dependency>
-    <groupId>org.apache.spark</groupId>
-    <artifactId>spark-catalyst_${scala.compat.version}</artifactId>
-    <version>${spark.version}</version>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-catalyst_${scala.compat.version}</artifactId>
+      <version>${spark.version}</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
@@ -77,6 +77,13 @@
       <artifactId>hadoop-aws</artifactId>
       <version>${hadoop.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-hive_${scala.compat.version}</artifactId>
+      <version>${spark.version}</version>
+    </dependency>
+
 
     <!-- Test -->
     <dependency>
@@ -123,6 +130,17 @@
       <version>0.40.15</version>
       <scope>test</scope>
     </dependency>
+
+    <!-- Used for HTML reports -->
+    <!-- https://mvnrepository.com/artifact/com.vladsch.flexmark/flexmark-all -->
+    <dependency>
+        <groupId>com.vladsch.flexmark</groupId>
+        <artifactId>flexmark-all</artifactId>
+        <version>0.61.34</version>
+        <scope>test</scope>
+    </dependency>
+
+
   </dependencies>
 
   <build>
@@ -166,40 +184,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.scalatest</groupId>
-        <artifactId>scalatest-maven-plugin</artifactId>
-        <version>2.2.0</version>
-        <configuration>
-          <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
-          <junitxml>.</junitxml>
-          <filereports>TestSuiteReport.txt</filereports>
-          <!-- Comma separated list of JUnit test class names to execute -->
-<!--          <jUnitClasses>com.gopetracca.appTest</jUnitClasses>-->
-        </configuration>
-        <executions>
-          <execution>
-            <id>test</id>
-            <goals>
-              <goal>test</goal>
-            </goals>
-            <configuration>
-              <suffixes>(?&lt;!Integration)(Test|Spec)</suffixes>
-            </configuration>
-          </execution>
-          <execution>
-            <id>integration-test</id>
-            <phase>integration-test</phase>
-            <goals>
-              <goal>test</goal>
-            </goals>
-            <configuration>
-              <suffixes>(?&lt;=Integration)(Test|Spec)</suffixes>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-    <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <version>2.4</version>
@@ -224,8 +208,92 @@
         </executions>
       </plugin>
 
+      <plugin>
+        <groupId>io.github.evis</groupId>
+        <artifactId>scalafix-maven-plugin_${scala.compat.version}</artifactId>
+        <version>0.1.8_0.10.4</version>
+        <configuration>
+
+          <skipTest>true</skipTest>
+        </configuration>
+      </plugin>
+
     </plugins>
 
   </build>
+
+
+  <profiles>
+    <profile>
+        <id>default-test</id>
+        <activation>
+            <activeByDefault>true</activeByDefault>
+        </activation>
+        <build>
+            <plugins>
+                <plugin>
+                    <groupId>net.alchim31.maven</groupId>
+                    <artifactId>scala-maven-plugin</artifactId>
+                </plugin>
+                <plugin>
+                    <groupId>org.scalatest</groupId>
+                    <artifactId>scalatest-maven-plugin</artifactId>
+                    <version>1.0</version>
+                    <configuration>
+                        <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+                        <junitxml>.</junitxml>
+                        <filereports>TestSuiteReport.txt</filereports>
+                        <htmlreporters>${project.build.directory}/html/scalatest</htmlreporters>
+                        <testFailureIgnore>false</testFailureIgnore>
+                        <tagsToExclude>IntegrationTest</tagsToExclude>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>test</id>
+                            <goals>
+                                <goal>test</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </build>
+    </profile>
+    <profile>
+        <id>integration-test</id>
+        <activation>
+            <activeByDefault>false</activeByDefault>
+        </activation>
+        <build>
+            <plugins>
+                <plugin>
+                    <groupId>net.alchim31.maven</groupId>
+                    <artifactId>scala-maven-plugin</artifactId>
+                </plugin>
+                <plugin>
+                    <groupId>org.scalatest</groupId>
+                    <artifactId>scalatest-maven-plugin</artifactId>
+                    <version>1.0</version>
+                    <configuration>
+                        <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+                        <junitxml>.</junitxml>
+                        <filereports>IntegrationTestSuiteReport.txt</filereports>
+                        <htmlreporters>${project.build.directory}/html/scalatest</htmlreporters>
+                        <testFailureIgnore>false</testFailureIgnore>
+                        <tagsToInclude>IntegrationTest</tagsToInclude>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>test</id>
+                            <goals>
+                                <goal>test</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </build>
+    </profile>
+</profiles>
 
 </project>

--- a/src/test/scala/com/gopetracca/Tags.scala
+++ b/src/test/scala/com/gopetracca/Tags.scala
@@ -1,0 +1,9 @@
+package com.gopetracca
+
+object Tags {
+  object UnitTest extends org.scalatest.Tag("UnitTest")
+
+  object IntegrationTest extends org.scalatest.Tag("IntegrationTest")
+
+  object FunctionalTest extends org.scalatest.Tag("FunctionalTest")
+}

--- a/src/test/scala/com/gopetracca/integration/UseCase1S3IntegrationTest.scala
+++ b/src/test/scala/com/gopetracca/integration/UseCase1S3IntegrationTest.scala
@@ -2,6 +2,7 @@ package com.gopetracca.logic
 
 import com.gopetracca.LocalStackContainerForAll
 import com.gopetracca.repositories._
+import com.gopetracca.Tags
 import com.holdenkarau.spark.testing.{ScalaDataFrameSuiteBase, SparkContextProvider}
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{Row, SparkSession}
@@ -36,7 +37,7 @@ class UseCase1S3IntegrationTest extends AnyFunSuite
       .set("spark.hadoop.fs.s3a.connection.ssl.enabled", "false") // Disable SSL for Localstack
   }
 
-  test("UseCase1: Return all adult users that gave consent") {
+  test("UseCase1: Return all adult users that gave consent", Tags.IntegrationTest) {
     import spark.implicits._
 
     Given("A Bucket containing User data where two Users.age > 18")

--- a/src/test/scala/com/gopetracca/logic/UseCase1Test.scala
+++ b/src/test/scala/com/gopetracca/logic/UseCase1Test.scala
@@ -1,17 +1,19 @@
 package com.gopetracca.logic
 
+import com.gopetracca.Tags
 import com.gopetracca.entities.{Consents, Users}
 import com.gopetracca.repositories._
 import com.holdenkarau.spark.testing.ScalaDataFrameSuiteBase
 import org.scalatest.GivenWhenThen
 import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.Tag
 
 
 class UseCase1Test extends AnyFunSuite with GivenWhenThen with ScalaDataFrameSuiteBase {
 
   import spark.implicits._
 
-  test("test FilterByAge method") {
+  test("test FilterByAge method", Tags.UnitTest) {
     Given("A DataFrame with two Users, only one is older than 18")
       val users = Seq(
         Users("John", 4, "Madrid"),
@@ -32,7 +34,7 @@ class UseCase1Test extends AnyFunSuite with GivenWhenThen with ScalaDataFrameSui
       assertDataFrameEquals(result, expected)
   }
 
-  test("test FilterByConsent method") {
+  test("test FilterByConsent method", Tags.UnitTest) {
 
     Given("A DataFrame with two Users where only one gave consent")
       val consents = Seq(


### PR DESCRIPTION
- Remove old suffix-based filtering for unit and integration tests. The issue was that when running integration tests, unit tests were executed as a previous step.

- Add Tag based tests
- Move integration tests to integration folder. 
- Create test profiles
- Update README to know how to run tests
- Modify pom to support html reports for tests